### PR TITLE
Implemented a few small fixes. Will always build once if started with watch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-sassy "1.0.5"
+(defproject lein-sassy "1.0.6-SNAPSHOT"
   :description "Use Sass with Clojure."
   :url "https://github.com/vladh/lein-sassy"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/lein_sassy/renderer.clj
+++ b/src/leiningen/lein_sassy/renderer.clj
@@ -1,4 +1,5 @@
 (ns leiningen.lein-sassy.renderer
+  (:refer-clojure :exclude [run!])
   (:require [leiningen.lein-sassy.ruby :refer :all]
             [leiningen.lein-sassy.file-utils :refer :all]
             [clojure.string :as s]
@@ -59,14 +60,14 @@
 (defn- file-change-handler
   "Prints the file that was changed then renders all templates."
   [container runtime options _1 _2 file]
-  (do (print-message "File" (:path file) "changed.")
+  (do (print-message "File " (:path file) " changed.")
       (render-all! container runtime options)))
 
 (defn watch-and-render!
   "Watches the directory specified by (:src options) and calls a handler that
   renders all templates."
   [container runtime options]
-  (print-message "Watching" (:src options) "for changes.")
+  (print-message "Watching " (:src options) " for changes.")
   (let [handler (partial file-change-handler container runtime options)
         fw (->  (file-watcher)
                 (on-file-create handler)

--- a/src/leiningen/sass.clj
+++ b/src/leiningen/sass.clj
@@ -13,6 +13,7 @@
 (defn- watch
   "Automatically recompile when files are modified."
   [container runtime options]
+  (render-all! container runtime options)
   (watch-and-render! container runtime options))
 
 (defn sass
@@ -28,6 +29,6 @@
       (let [{container :container runtime :runtime} (init-renderer options)]
         (case subtask
           "once" (once container runtime options)
-          "watch" (watch container runtime options)
+          (or "auto" "watch") (watch container runtime options)
           (lmain/warn subtask " not found.")))
       ((resolve 'leiningen.core.main/abort) "Invalid options in project.clj."))))


### PR DESCRIPTION
Changes in detail:
- always starting the renderer when started with 'watch'. Previously, after a lein clean
  there was no output and lein sass watch would not create new one.
- spaces in messages
- 'auto' as alias for 'watch'
- exclude clojure.core/run! from import as this will collide with panoptics run! in Clojure 1.7.0